### PR TITLE
Fix WolfEntityMixin so it doesn't break mixins into the same class from other mods

### DIFF
--- a/src/main/java/net/lordmrk/dmo/mixin/WolfEntityMixin.java
+++ b/src/main/java/net/lordmrk/dmo/mixin/WolfEntityMixin.java
@@ -34,11 +34,16 @@ public class WolfEntityMixin extends TameableEntity {
 
     @Inject(method = "interactMob(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/ActionResult;"
             , at = @At(value = "INVOKE"
-                , target = "Lnet/minecraft/world/World;sendEntityStatus(Lnet/minecraft/entity/Entity;B)V", shift = At.Shift.AFTER, ordinal = 0))
+                , target = "Lnet/minecraft/entity/passive/WolfEntity;setOwner(Lnet/minecraft/entity/player/PlayerEntity;)V")
+            , cancellable = true)
     private void interactMob(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> ci) {
         DoggoEntity doggoEntity = DoggoEntities.DOGGO_ENTITY.spawn((ServerWorld)this.getWorld(), null/*, this.getCustomName()*/, null, this.getBlockPos(), SpawnReason.CONVERSION, true, false);
         doggoEntity.setOwner(player);
+        this.getWorld().sendEntityStatus(doggoEntity, (byte)7);
         this.remove(RemovalReason.DISCARDED);
+
+        ci.cancel();
+        ci.setReturnValue(ActionResult.SUCCESS);
     }
 
     @Override

--- a/src/main/java/net/lordmrk/dmo/mixin/WolfEntityMixin.java
+++ b/src/main/java/net/lordmrk/dmo/mixin/WolfEntityMixin.java
@@ -34,16 +34,11 @@ public class WolfEntityMixin extends TameableEntity {
 
     @Inject(method = "interactMob(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/ActionResult;"
             , at = @At(value = "INVOKE"
-                , target = "Lnet/minecraft/entity/passive/WolfEntity;setOwner(Lnet/minecraft/entity/player/PlayerEntity;)V")
-            , cancellable = true)
+                , target = "Lnet/minecraft/world/World;sendEntityStatus(Lnet/minecraft/entity/Entity;B)V", shift = At.Shift.AFTER, ordinal = 0))
     private void interactMob(PlayerEntity player, Hand hand, CallbackInfoReturnable<ActionResult> ci) {
         DoggoEntity doggoEntity = DoggoEntities.DOGGO_ENTITY.spawn((ServerWorld)this.getWorld(), null/*, this.getCustomName()*/, null, this.getBlockPos(), SpawnReason.CONVERSION, true, false);
         doggoEntity.setOwner(player);
-        this.getWorld().sendEntityStatus(doggoEntity, (byte)7);
         this.remove(RemovalReason.DISCARDED);
-
-        ci.cancel();
-        ci.setReturnValue(ActionResult.SUCCESS);
     }
 
     @Override

--- a/src/main/java/net/lordmrk/dmo/mixin/WolfEntityMixin.java
+++ b/src/main/java/net/lordmrk/dmo/mixin/WolfEntityMixin.java
@@ -20,16 +20,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(WolfEntity.class)
-public class WolfEntityMixin extends TameableEntity {
+abstract class WolfEntityMixin extends TameableEntity {
 
     protected WolfEntityMixin(EntityType<? extends TameableEntity> entityType, World world) {
         super(entityType, world);
-    }
-
-    @Nullable
-    @Override
-    public PassiveEntity createChild(ServerWorld world, PassiveEntity entity) {
-        return null;
     }
 
     @Inject(method = "interactMob(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/Hand;)Lnet/minecraft/util/ActionResult;"
@@ -44,10 +38,5 @@ public class WolfEntityMixin extends TameableEntity {
 
         ci.cancel();
         ci.setReturnValue(ActionResult.SUCCESS);
-    }
-
-    @Override
-    public EntityView method_48926() {
-        return null;
     }
 }


### PR DESCRIPTION
A fix for #23. <s>This is easier to change on your end as you don't necessarily need your injection to happen before the wolf is tamed while I do (since I want to prevent it). The issue itself shouldn't really happen, but that comes down to the mixin framework itself.

Moving the injection here to after the taming doesn't make a difference as the vanilla wolf is discarded anyway.</s>